### PR TITLE
Remove SkipUsingCrossgen

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
           mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-cross-riscv64 \
           sh -c '
             ./prep-source-build.sh &&
-            ./build.sh --clean-while-building -sb --os linux --arch riscv64 -p:SkipUsingCrossgen=true -p:DisableDevBuildAsDefaultForSourceOnly=true
+            ./build.sh --clean-while-building -sb --os linux --arch riscv64 -p:DisableDevBuildAsDefaultForSourceOnly=true
           '
 
     - name: List assets directory


### PR DESCRIPTION
Removing one of two special property. Now SDK builds without SkipUsingCrossgen (https://github.com/dotnet/sdk/commit/87c30754f2572a5c5788ccf7848b0b3f3880bed5 and https://github.com/dotnet/sdk/commit/0b589371f4495e68968be99e7f0029b24cf21f14). Chances are after https://github.com/dotnet/dotnet/pull/400#discussion_r2087756009, we won't be needing `DisableDevBuildAsDefaultForSourceOnly` either.