### PR TITLE
Use new arg `--prep`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,11 @@ name: Build .NET SDK
 on:
   workflow_dispatch:
     inputs:
+      fork:
+        description: 'dotnet VMR fork name'
+        required: true
+        type: string
+        default: dotnet
       branch:
         description: 'dotnet VMR branch name'
         required: true
@@ -26,16 +31,13 @@ jobs:
 
     - name: Clone repository
       run: |
-        git clone --depth 1 -b ${{ inputs.branch }} https://github.com/dotnet/dotnet
+        git clone --single-branch --depth 1 -b ${{ inputs.branch }} https://github.com/${{ inputs.fork }}/dotnet
 
     - name: Build
       run: |
         docker run --platform linux/amd64 --rm -v${{ github.workspace }}/dotnet:/dotnet -w /dotnet -e ROOTFS_DIR=/crossrootfs/riscv64 \
           mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-cross-riscv64 \
-          sh -c '
-            ./prep-source-build.sh &&
-            ./build.sh --clean-while-building -sb --os linux --arch riscv64 -p:DisableDevBuildAsDefaultForSourceOnly=true
-          '
+            ./build.sh --clean-while-building --prep -sb --os linux --arch riscv64
 
     - name: List assets directory
       run: |


### PR DESCRIPTION
Build command is now one liner without `DisableDevBuildAsDefaultForSourceOnly` workaround.