### PR TITLE
Add workflow to dispatch build 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,15 @@ on:
         required: true
         type: string
         default: main
+      branding:
+        description: 'SDK branding'
+        required: true
+        type: choice
+        options:
+          - unstable
+          - preview
+          - release
+        default: preview
       release:
         description: 'publish release'
         type: boolean
@@ -30,9 +39,12 @@ jobs:
           - name: linux-musl
             libc: musl
             docker_tag: azurelinux-3.0-net10.0-cross-riscv64-musl
+
     runs-on: ubuntu-latest
+
     permissions:
       contents: write
+
     steps:
     - name: Maximize build space
       uses: AdityaGarg8/remove-unwanted-software@v4.1
@@ -49,9 +61,20 @@ jobs:
 
     - name: Build
       run: |
+        major_version=$(echo "${{ inputs.branch }}" | sed -E 's/^v?([0-9]+)\..*/\1/')
+
+        branding_arg=""
+        if [[ "$major_version" =~ ^[0-9]+$ ]] && [ "$major_version" -ge 11 ]; then
+          branding_arg="--branding ${{ inputs.branding }}"
+        fi
+
+        echo "Major version: $major_version"
+        echo "Branding argument: $branding_arg"
+
         docker run --platform linux/amd64 --rm -v${{ github.workspace }}/dotnet:/dotnet -w /dotnet -e ROOTFS_DIR=/crossrootfs/riscv64 \
           mcr.microsoft.com/dotnet-buildtools/prereqs:${{ matrix.docker_tag }} \
-            ./build.sh --clean-while-building --prep -sb --os ${{ matrix.name }} --rid ${{ matrix.name }}-riscv64 --arch riscv64 -p:OfficialBuildId=$(date +%Y%m%d).99
+            ./build.sh --clean-while-building --prep -sb --os ${{ matrix.name }} --rid ${{ matrix.name }}-riscv64 --arch riscv64 \
+              $branding_arg -p:OfficialBuildId=$(date +%Y%m%d).99
 
     - name: List assets directory
       run: |
@@ -67,37 +90,50 @@ jobs:
   release:
     needs: build
     runs-on: ubuntu-latest
+    if: always() && inputs.release
+
     permissions:
       contents: write
-    if: ${{ inputs.release }}
+
     steps:
     - name: Download artifacts
+      if: needs.build.result == 'success'
       uses: actions/download-artifact@v4
       with:
         path: artifacts
 
-    - name: Make release
+    - name: Make release (Success)
+      if: needs.build.result == 'success'
       run: |
-        sudo apt install -y hub
+        sdk_paths=$(find "${{ github.workspace }}/artifacts" -name 'dotnet-sdk-*.tar.gz')
 
-        # hub(1) requires release to be created inside a git repo
-        git clone https://${{ secrets.CLONE_TOKEN }}:x-oauth-basic@github.com/${{ github.repository }}.git repo
-        cd repo
-
-        sdk_paths=$(find ${{ github.workspace }}/artifacts -name 'dotnet-sdk-*.tar.gz')
         artifacts=""
+        tag_name=""
+
         for sdk_path in $sdk_paths; do
           sdk_filename=$(basename "$sdk_path")
-          # Extract version: strip prefix/suffix to get e.g. "10.0.100-preview.5.25277.114"
           sdk_version=$(echo "$sdk_filename" | sed -E 's/dotnet-sdk-([^-]+(-[^-]+)*)-linux-.+\.tar\.gz/\1/')
-          artifacts="$artifacts -a $sdk_path"
+          artifacts="$artifacts $sdk_path"
           tag_name="$sdk_version"
         done
 
         echo "tag_name: $tag_name"
         echo "artifacts: $artifacts"
 
-        # docs: https://hub.github.com/hub-release.1.html
-        hub release create $artifacts --prerelease -m "$tag_name" "$tag_name"
+        if [ "${{ inputs.branding }}" = "release" ]; then
+          gh release create "$tag_name" $artifacts --repo "${{ github.repository }}" --target "${{ github.sha }}" --title "$tag_name" --notes "$tag_name"
+        else
+          gh release create "$tag_name" $artifacts --repo "${{ github.repository }}" --target "${{ github.sha }}" --title "$tag_name" --notes "$tag_name" --prerelease
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Create failed tag
+      if: needs.build.result == 'failure' && inputs.branch != 'main'
+      run: |
+        tag_name="${{ inputs.branch }}.${{ github.run_id }}.failed"
+        echo "tag_name: $tag_name"
+
+        gh api repos/${{ github.repository }}/git/refs -f ref="refs/tags/$tag_name" -f sha="${{ github.sha }}"
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,7 @@
 name: Build .NET SDK
 
+run-name: "Build .NET SDK : ${{ inputs.branch }}"
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/check-and-dispatch.yml
+++ b/.github/workflows/check-and-dispatch.yml
@@ -45,6 +45,19 @@ jobs:
 
           static string Normalize(string tag)
           {
+              // If it's a failed variant, strip the trailing .<run_id>.failed to get the original tag name
+              if (tag.EndsWith(".failed", StringComparison.OrdinalIgnoreCase))
+              {
+                  // Remove ".failed"
+                  tag = tag.Substring(0, tag.Length - 7);
+                  // Remove the trailing dot and run_id (e.g., .123456789)
+                  int lastDot = tag.LastIndexOf('.');
+                  if (lastDot > 0)
+                  {
+                      tag = tag.Substring(0, lastDot);
+                  }
+              }
+
               tag = tag.TrimStart('v');
 
               if (NuGetVersion.TryParse(tag, out var version))

--- a/.github/workflows/check-and-dispatch.yml
+++ b/.github/workflows/check-and-dispatch.yml
@@ -1,0 +1,139 @@
+name: Check Upstream Tags and Trigger Build
+
+on:
+  schedule:
+    - cron: "0 13 * * *" # UTC 13:00 daily
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: write
+
+jobs:
+  check-tags:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Fetch tags
+        run: |
+          set -euo pipefail
+
+          curl -fsSL \
+            https://api.github.com/repos/dotnet/dotnet/tags?per_page=100 |
+            jq -r '.[].name' > upstream-tags.txt
+
+          git fetch --tags
+
+          git tag > local-tags.txt
+
+      - name: Determine builds
+        id: builds
+        run: |
+          dotnet run - -- upstream-tags.txt local-tags.txt <<'EOF'
+          #:package NuGet.Versioning@*
+
+          using NuGet.Versioning;
+          using System.Text.Json;
+          using System.Text.Json.Serialization;
+
+          var upstreamTags = File.ReadAllLines(args[0]);
+          var localTags = File.ReadAllLines(args[1]);
+
+          static string Normalize(string tag)
+          {
+              tag = tag.TrimStart('v');
+
+              if (NuGetVersion.TryParse(tag, out var version))
+              {
+                  if (version.IsPrerelease)
+                  {
+                      var first = version.ReleaseLabels.First();
+                      var second = version.ReleaseLabels.Skip(1).FirstOrDefault();
+
+                      if ((first == "preview" || first == "rc") && second != null)
+                          return $"{version.Major}.{version.Minor}.{version.Patch}-{first}.{second}";
+                  }
+
+                  return version.ToNormalizedString();
+              }
+
+              return tag;
+          }
+
+          var built = localTags
+              .Select(Normalize)
+              .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+          var builds = new List<BuildItem>();
+
+          foreach (var raw in upstreamTags)
+          {
+              if (!NuGetVersion.TryParse(raw.TrimStart('v'), out var version))
+                  continue;
+
+              if (version.Major < 10)
+                  continue;
+
+              if (version.Minor != 0)
+                  continue;
+
+              if (version.Patch < 100 || version.Patch >= 200)
+                  continue;
+
+              if (version.IsPrerelease)
+              {
+                  var label = version.ReleaseLabels.FirstOrDefault();
+
+                  if (label is not ("preview" or "rc"))
+                      continue;
+              }
+
+              var normalized = Normalize(raw);
+
+              if (built.Contains(normalized))
+                  continue;
+
+              builds.Add(new BuildItem(raw, version.IsPrerelease ? "preview" : "release"));
+          }
+
+          string json = JsonSerializer.Serialize(builds, BuildItemContext.Default.ListBuildItem);
+          File.WriteAllText("/tmp/tags.json", json);
+
+          public record BuildItem(string tag, string branding);
+
+          [JsonSerializable(typeof(List<BuildItem>))]
+          internal partial class BuildItemContext : JsonSerializerContext { }
+          EOF
+
+          jq . /tmp/tags.json
+
+          count=$(jq length /tmp/tags.json)
+          echo "count=$count" >> "$GITHUB_OUTPUT"
+
+      - name: Trigger builds
+        if: steps.builds.outputs.count != '0'
+        env:
+          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          jq -c '.[]' /tmp/tags.json |
+          while read -r build; do
+            tag=$(jq -r '.tag' <<<"$build")
+            branding=$(jq -r '.branding' <<<"$build")
+
+            echo "Dispatching $tag ($branding)"
+
+            gh workflow run build.yml \
+              --ref main \
+              -f fork=dotnet \
+              -f branch="$tag" \
+              -f branding="$branding" \
+              -f release=true
+
+            sleep 5
+          done


### PR DESCRIPTION
* Fetch dotnet/dotnet tags
* Fetch filipnavara/dotnet-riscv tags
* Pass both sets to a C# program to parse lists using `NuGet.Versioning` semver parser and filter out 1xx band, -preview, -rc etc. which aren't built yet.


- [x] To trigger workflows, we need a PAT (action required by @filipnavara):
	
  * Go to `GitHub Settings` -> `Developer settings` -> `Personal access tokens` -> `Fine-grained tokens`.
  * Click `Generate new token`, name it, and set an expiration.
  * Under `Repository access`, select `Only select repositories` and pick your target repo.
  * Under `Repository permissions`, change `Actions` to `Read and write`.
  * Click `Generate token` and copy the value.
  * Go to your repository's `Settings` -> `Secrets and variables` -> `Actions` -> `New repository secret`.
  * Name it `PAT_TOKEN`, paste the token, and click `Add secret`.

- [x] invalid tag https://github.com/dotnet/dotnet/issues/8196 - I can filter it out with additional logic, but wanted to start off clean.


